### PR TITLE
Replaced outdated tf.pack with tf.stack

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -380,8 +380,8 @@ def mask_style_layer(a, x, mask_img):
   tensors = []
   for _ in range(d.value): 
     tensors.append(mask)
-  mask = tf.pack(tensors, axis=2)
-  mask = tf.pack(mask, axis=0)
+  mask = tf.stack(tensors, axis=2)
+  mask = tf.stack(mask, axis=0)
   mask = tf.expand_dims(mask, 0)
   a = tf.mul(a, mask)
   x = tf.mul(x, mask)


### PR DESCRIPTION
This resolves the issue posted in https://github.com/cysmith/neural-style-tf/issues/18.

tf.pack was replaced by tf.stack in 2016.