### PR TITLE
Fix print exception in minimize_with_adam function

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -613,7 +613,7 @@ def minimize_with_adam(sess, net, optimizer, init_img, loss):
     sess.run(train_op)
     if iterations % args.print_iterations == 0 and args.verbose:
       curr_loss = loss.eval()
-      print("At iterate {}\tf=  {:.5E}".format(iterations, curr_loss))
+      print("At iterate {}\tf=  {}".format(iterations, curr_loss))
     iterations += 1
 
 def get_optimizer(loss):


### PR DESCRIPTION
When issuing the following command to render an image with Adam optimizer, encounter the below exception.
python neural_style.py --optimizer adam --style_imgs kandinsky.jpg --content_img  lion.jpg --verbose

exception message is as below:
    print("At iterate {}\tf=  {:.5E}".format(iterations, curr_loss))
TypeError: unsupported format string passed to numpy.ndarray.__format__

It seems the numpy ndarray doesn't support the format arguments.
The code block is changed as below, exception gone.

print("At iterate {}\tf=  {}".format(iterations, curr_loss))

environment:
Window7
Anaconda3(Python-3.5, numpy-1.14.1, tensorflow-1.5.0)