### PR TITLE
feat: extending python 3 support

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -524,7 +524,7 @@ def read_weights_file(path):
   for i in range(1, len(lines)):
     line = lines[i].rstrip().split(' ')
     vals[i-1] = np.array(list(map(np.float32, line)))
-    vals[i-1] = list(map(lambda x: 0. if x < 255. else 1., vals[i-1]))
+    vals[i-1] = list([0. if x < 255. else 1. for x in vals[i-1]])
   # expand to 3 channels
   weights = np.dstack([vals.astype(np.float32)] * 3)
   return weights


### PR DESCRIPTION
The project runs fine with python 3.6 and tf.1.10, but these changes are not compatible with python2.

[1]: Python 3 changes return values of several basic functions from list to iterator. The main reason for this change is that iterators usually cause better memory consumption than lists.

1: https://portingguide.readthedocs.io/en/latest/iterators.html